### PR TITLE
Fix for cartesian impedance controller

### DIFF
--- a/franka_bringup/launch/cartesian_impedance_example_controller.launch.py
+++ b/franka_bringup/launch/cartesian_impedance_example_controller.launch.py
@@ -68,7 +68,7 @@ def generate_launch_description():
         ),
         Node(
             package='franka_example_controllers',
-            executable='equilibrium_pose_publisher',
+            executable='interactive_marker.py',
             output='screen',
         ),
     ])

--- a/franka_example_controllers/CMakeLists.txt
+++ b/franka_example_controllers/CMakeLists.txt
@@ -28,13 +28,6 @@ find_package(moveit_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 
 
-add_executable(equilibrium_pose_publisher src/equilibrium_pose_publisher.cpp)
-# Link the executable with the necessary libraries
-ament_target_dependencies(equilibrium_pose_publisher
-  rclcpp
-  geometry_msgs
-)
-
 add_library(
         ${PROJECT_NAME}
         SHARED
@@ -85,6 +78,8 @@ install(
         DIRECTORY include/
         DESTINATION include
 )
+
+install(PROGRAMS scripts/interactive_marker.py DESTINATION lib/${PROJECT_NAME})
 
 if(BUILD_TESTING)
     find_package(ament_cmake_clang_format REQUIRED)

--- a/franka_example_controllers/franka_example_controllers.xml
+++ b/franka_example_controllers/franka_example_controllers.xml
@@ -72,7 +72,7 @@
         </description>
     </class>
     <class name="franka_example_controllers/CartesianImpedanceExampleController" 
-           type="franka_example_controllers::CartesianImpedanceExampleController" base_class_type="controller_interface::ControllerBase">
+           type="franka_example_controllers::CartesianImpedanceExampleController" base_class_type="controller_interface::ControllerInterface">
         <description>
         A controller that renders a spring damper system in cartesian space. Compliance parameters and the equilibrium pose can be modified online with dynamic reconfigure and an interactive marker respectively.
         </description>

--- a/franka_example_controllers/include/franka_example_controllers/cartesian_impedance_example_controller.hpp
+++ b/franka_example_controllers/include/franka_example_controllers/cartesian_impedance_example_controller.hpp
@@ -61,11 +61,6 @@ class CartesianImpedanceExampleController : public controller_interface::Control
   std::string arm_id_;
   int num_joints{7};
 
-  // Saturation
-  Eigen::Matrix<double, 7, 1> saturateTorqueRate(
-      const Eigen::Matrix<double, 7, 1>& tau_d_calculated,
-      const Eigen::Matrix<double, 7, 1>& tau_j_d);
-
   // Classic cartesian controller
   double filter_params_{0.005};
   double nullspace_stiffness_{20.0};

--- a/franka_example_controllers/include/franka_example_controllers/cartesian_impedance_example_controller.hpp
+++ b/franka_example_controllers/include/franka_example_controllers/cartesian_impedance_example_controller.hpp
@@ -70,12 +70,14 @@ class CartesianImpedanceExampleController : public controller_interface::Control
   double filter_params_{0.005};
   double nullspace_stiffness_{20.0};
   double nullspace_stiffness_target_{20.0};
+  double translational_stiffness_{250.0};
+  double translational_stiffness_target_{250.0};
+  double rotational_stiffness_{30.0};
+  double rotational_stiffness_target_{30.0};
   const double delta_tau_max_{1.0};
 
   Eigen::Matrix<double, 6, 6> cartesian_stiffness_;
-  Eigen::Matrix<double, 6, 6> cartesian_stiffness_target_;
   Eigen::Matrix<double, 6, 6> cartesian_damping_;
-  Eigen::Matrix<double, 6, 6> cartesian_damping_target_;
   Eigen::Matrix<double, 7, 1> q_d_nullspace_;
   Eigen::Vector3d position_d_;
   Eigen::Quaterniond orientation_d_;

--- a/franka_example_controllers/scripts/interactive_marker.py
+++ b/franka_example_controllers/scripts/interactive_marker.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python
+
+from scipy.spatial.transform import Rotation as R
+import numpy as np
+
+
+import rclpy
+from rclpy.node import Node
+from rclpy.wait_for_message import wait_for_message
+from tf2_ros import TransformException
+from tf2_ros.buffer import Buffer
+from tf2_ros.transform_listener import TransformListener
+from interactive_markers.interactive_marker_server import \
+    InteractiveMarkerServer, InteractiveMarkerFeedback
+from visualization_msgs.msg import InteractiveMarker, InteractiveMarkerControl, Marker
+from geometry_msgs.msg import PoseStamped
+from franka_msgs.msg import FrankaRobotState
+
+marker_pose = PoseStamped()
+pose_pub = None
+# [[min_x, max_x], [min_y, max_y], [min_z, max_z]]
+position_limits = [[-0.6, 0.6], [-0.6, 0.6], [0.05, 0.9]]
+
+
+def publisher_callback():
+    marker_pose.header.stamp = rclpy.time.Time().to_msg()
+    pose_pub.publish(marker_pose)
+
+
+def process_feedback(feedback):
+    if feedback.event_type == InteractiveMarkerFeedback.POSE_UPDATE:
+        marker_pose.pose.position.x = max([min([feedback.pose.position.x,
+                                          position_limits[0][1]]),
+                                          position_limits[0][0]])
+        marker_pose.pose.position.y = max([min([feedback.pose.position.y,
+                                          position_limits[1][1]]),
+                                          position_limits[1][0]])
+        marker_pose.pose.position.z = max([min([feedback.pose.position.z,
+                                          position_limits[2][1]]),
+                                          position_limits[2][0]])
+        marker_pose.pose.orientation = feedback.pose.orientation
+    server.applyChanges()
+
+def make_sphere(scale=0.3):
+    """
+    This function returns sphere marker for 3D translational movements.
+    :param scale: scales the size of the sphere
+    :return: sphere marker
+    """
+    marker = Marker()
+    marker.type = Marker.SPHERE
+    marker.scale.x = scale * 0.45
+    marker.scale.y = scale * 0.45
+    marker.scale.z = scale * 0.45
+    marker.color.r = 0.5
+    marker.color.g = 0.5
+    marker.color.b = 0.5
+    marker.color.a = 1.0
+    return marker
+
+if __name__ == "__main__":
+    rclpy.init()
+    node = Node("equilibrium_pose_node")
+    # buffer = Buffer()
+    # listener = TransformListener(buffer, node)
+    link_name = 'fr3_link0' # node.get_parameter('~link_name').get_parameter_value().string_value
+
+    print("Waiting for robot state message...")
+    result, msg = wait_for_message(FrankaRobotState, node, "/franka_robot_state_broadcaster/robot_state")
+    if not result:
+        print("Failed to receive robot state message.")
+        rclpy.shutdown()
+        exit(1)
+    print("Equilibrium pose node started")
+    marker_pose.pose = msg.o_t_ee.pose
+
+    pose_pub = node.create_publisher(
+        PoseStamped, "equilibrium_pose", 10)
+    
+    server = InteractiveMarkerServer(node, "equilibrium_pose_marker")
+    int_marker = InteractiveMarker()
+    int_marker.header.frame_id = link_name
+    int_marker.scale = 0.3
+    int_marker.name = "equilibrium_pose"
+    int_marker.description = ("Equilibrium Pose\nBE CAREFUL! "
+                              "If you move the \nequilibrium "
+                              "pose the robot will follow it\n"
+                              "so be aware of potential collisions")
+    int_marker.pose = marker_pose.pose
+    # run pose publisher
+    marker_pose.header.frame_id = link_name
+    timer = node.create_timer(0.005, publisher_callback)
+
+    # insert a box
+    control = InteractiveMarkerControl()
+    control.orientation.w = 1.0
+    control.orientation.x = 1.0
+    control.orientation.y = 0.0
+    control.orientation.z = 0.0
+    control.name = "rotate_x"
+    control.interaction_mode = InteractiveMarkerControl.ROTATE_AXIS
+    int_marker.controls.append(control)
+
+    control = InteractiveMarkerControl()
+    control.orientation.w = 1.0
+    control.orientation.x = 1.0
+    control.orientation.y = 0.0
+    control.orientation.z = 0.0
+    control.name = "move_x"
+    control.interaction_mode = InteractiveMarkerControl.MOVE_AXIS
+    int_marker.controls.append(control)
+    control = InteractiveMarkerControl()
+    control.orientation.w = 1.0
+    control.orientation.x = 0.0
+    control.orientation.y = 1.0
+    control.orientation.z = 0.0
+    control.name = "rotate_y"
+    control.interaction_mode = InteractiveMarkerControl.ROTATE_AXIS
+    int_marker.controls.append(control)
+    control = InteractiveMarkerControl()
+    control.orientation.w = 1.0
+    control.orientation.x = 0.0
+    control.orientation.y = 1.0
+    control.orientation.z = 0.0
+    control.name = "move_y"
+    control.interaction_mode = InteractiveMarkerControl.MOVE_AXIS
+    int_marker.controls.append(control)
+    control = InteractiveMarkerControl()
+    control.orientation.w = 1.0
+    control.orientation.x = 0.0
+    control.orientation.y = 0.0
+    control.orientation.z = 1.0
+    control.name = "rotate_z"
+    control.interaction_mode = InteractiveMarkerControl.ROTATE_AXIS
+    int_marker.controls.append(control)
+    control = InteractiveMarkerControl()
+    control.orientation.w = 1.0
+    control.orientation.x = 0.0
+    control.orientation.y = 0.0
+    control.orientation.z = 1.0
+    control.name = "move_z"
+    control.interaction_mode = InteractiveMarkerControl.MOVE_AXIS
+    int_marker.controls.append(control)
+    control = InteractiveMarkerControl()
+    control.orientation.w = 1.0
+    control.orientation.x = 1.0
+    control.orientation.y = 1.0
+    control.orientation.z = 1.0
+    control.name = "move_3d"
+    control.always_visible = True
+    control.markers.append(make_sphere())
+    control.interaction_mode = InteractiveMarkerControl.MOVE_3D
+
+    int_marker.controls.append(control)
+    server.insert(int_marker, feedback_callback=process_feedback)
+
+    server.applyChanges()
+
+    rclpy.spin(node)

--- a/franka_example_controllers/src/cartesian_impedance_example_controller.cpp
+++ b/franka_example_controllers/src/cartesian_impedance_example_controller.cpp
@@ -22,18 +22,16 @@ CartesianImpedanceExampleController::CallbackReturn CartesianImpedanceExampleCon
   orientation_d_target_.coeffs() << 0.0, 0.0, 0.0, 1.0;
 
   // Compliance parameters
-  const double translational_stiffness{150.0};
-  const double rotational_stiffness{10.0};
   cartesian_stiffness_.setZero();
   cartesian_stiffness_.topLeftCorner(3, 3)
-      << translational_stiffness * Eigen::MatrixXd::Identity(3, 3);
+      << translational_stiffness_ * Eigen::MatrixXd::Identity(3, 3);
   cartesian_stiffness_.bottomRightCorner(3, 3)
-      << rotational_stiffness * Eigen::MatrixXd::Identity(3, 3);
+      << rotational_stiffness_ * Eigen::MatrixXd::Identity(3, 3);
   cartesian_damping_.setZero();
   cartesian_damping_.topLeftCorner(3, 3)
-      << 2.0 * sqrt(translational_stiffness) * Eigen::MatrixXd::Identity(3, 3);
+      << 2.0 * sqrt(translational_stiffness_) * Eigen::MatrixXd::Identity(3, 3);
   cartesian_damping_.bottomRightCorner(3, 3)
-      << 2.0 * sqrt(rotational_stiffness) * Eigen::MatrixXd::Identity(3, 3);
+      << 2.0 * sqrt(rotational_stiffness_) * Eigen::MatrixXd::Identity(3, 3);
   return CallbackReturn::SUCCESS;
 }
 
@@ -182,19 +180,17 @@ controller_interface::return_type CartesianImpedanceExampleController::update(
   // Desired torque
   tau_d << tau_task + tau_nullspace + coriolis;
 
-  // saturate the commanded torque to joint limits
-  tau_d << saturateTorqueRate(tau_d, tau_j_d);
 
   for (int i = 0; i < num_joints; i++) {
     command_interfaces_[i].set_value(tau_d[i]);
   }
 
-  // update parameters changed online either through dynamic reconfigure or through the interactive
+  // TODO: update parameters changed online either through dynamic reconfigure or through the interactive
   // target by filtering
-  cartesian_stiffness_ =
-      filter_params_ * cartesian_stiffness_target_ + (1.0 - filter_params_) * cartesian_stiffness_;
-  cartesian_damping_ =
-      filter_params_ * cartesian_damping_target_ + (1.0 - filter_params_) * cartesian_damping_;
+  translational_stiffness_ =
+      filter_params_ * translational_stiffness_target_ + (1.0 - filter_params_) * translational_stiffness_;
+  rotational_stiffness_ =
+      filter_params_ * rotational_stiffness_target_ + (1.0 - filter_params_) * rotational_stiffness_;
   nullspace_stiffness_ =
       filter_params_ * nullspace_stiffness_target_ + (1.0 - filter_params_) * nullspace_stiffness_;
 
@@ -202,7 +198,7 @@ controller_interface::return_type CartesianImpedanceExampleController::update(
       position_and_orientation_d_target_mutex_);
   position_d_ = filter_params_ * position_d_target_ + (1.0 - filter_params_) * position_d_;
   orientation_d_ = orientation_d_.slerp(filter_params_, orientation_d_target_);
-
+  
   return controller_interface::return_type::OK;
 }
 

--- a/franka_example_controllers/src/cartesian_impedance_example_controller.cpp
+++ b/franka_example_controllers/src/cartesian_impedance_example_controller.cpp
@@ -226,18 +226,6 @@ void CartesianImpedanceExampleController::equilibriumPoseCallback(
     orientation_d_target_.coeffs() << -orientation_d_target_.coeffs();
   }
 }
-
-Eigen::Matrix<double, 7, 1> CartesianImpedanceExampleController::saturateTorqueRate(
-    const Eigen::Matrix<double, 7, 1>& tau_d_calculated,
-    const Eigen::Matrix<double, 7, 1>& tau_j_d) {  // NOLINT (readability-identifier-naming)
-  Eigen::Matrix<double, 7, 1> tau_d_saturated{};
-  for (size_t i = 0; i < 7; i++) {
-    double difference = tau_d_calculated[i] - tau_j_d[i];
-    tau_d_saturated[i] =
-        tau_j_d[i] + std::max(std::min(difference, delta_tau_max_), -delta_tau_max_);
-  }
-  return tau_d_saturated;
-}
 }  // namespace franka_example_controllers
 
 // Expose the controller as visible to the rest of ros2_control

--- a/franka_semantic_components/CMakeLists.txt
+++ b/franka_semantic_components/CMakeLists.txt
@@ -19,6 +19,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
     franka_msgs
     geometry_msgs
     sensor_msgs
+    controller_interface
     hardware_interface
     rclcpp_lifecycle
     urdf)

--- a/franka_semantic_components/package.xml
+++ b/franka_semantic_components/package.xml
@@ -14,6 +14,7 @@
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>hardware_interface</depend>
+  <depend>controller_interface</depend> # add
   <depend>franka_hardware</depend>
 
   <test_depend>ament_cmake_clang_format</test_depend>


### PR DESCRIPTION
Fixed the problem with the cartesian impedance controller running into limits. The main issue was that the torque saturation was sending the new absolute torques as targets, whereas the relative torques need to be sent instead, if I understood it correctly.

Removing [`saturateTorqueRate`](https://github.com/sp-sophia-labs/franka_ros2/blob/64966bf59f95f9bf25446bb26ee5e2908d3c6b77/franka_example_controllers/src/cartesian_impedance_example_controller.cpp#L234) at the following line (and subsequently tuning the stiffness gains) helped stabilize the behaviour:

https://github.com/sp-sophia-labs/franka_ros2/blob/64966bf59f95f9bf25446bb26ee5e2908d3c6b77/franka_example_controllers/src/cartesian_impedance_example_controller.cpp#L186

![franka-cartesian-impedance-small-cropped](https://github.com/user-attachments/assets/77725bef-79f5-4753-8aa4-df5be7383195)
